### PR TITLE
Add pytest benchmarking extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 This repo serves as an example of how to unit-test code for UAV Forge. To run the tests, run the `run_tests.sh` script.
+
+Confirmed working with Python 3.10.10 on Arch Linux.

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -1,0 +1,299 @@
+# This is the output of `pip freeze` on a system running python 3.10 that this repo runs successfully on
+# You can compare this with the output of `pip freeze` on your machine to see if there are any differences
+# This may contain extra packages that are not required for this repo to run, but it does contain all the packages that are required
+absl-py==1.4.0
+actionlib==1.13.2
+addict==2.4.0
+aiogrpc==1.8
+anyio==3.6.2
+argcomplete==3.0.5
+argon2-cffi==21.3.0
+argon2-cffi-bindings==21.2.0
+arrow==1.2.3
+astroid==2.15.4
+asttokens @ file:///opt/conda/conda-bld/asttokens_1646925590279/work
+astunparse==1.6.3
+attrs==22.2.0
+backcall @ file:///home/ktietz/src/ci/backcall_1611930011877/work
+beautifulsoup4==4.12.2
+bleach==6.0.0
+bokeh==2.4.3
+boltons @ file:///croot/boltons_1677628692245/work
+bondpy==1.8.6
+brotlipy==0.7.0
+cachetools==5.3.0
+cameratransform==1.2
+catkin==0.8.10
+catkin-pkg==0.5.2
+Cerberus==1.3.4
+certifi==2022.12.7
+cffi @ file:///croot/cffi_1670423208954/work
+charset-normalizer @ file:///tmp/build/80754af9/charset-normalizer_1630003229654/work
+click==8.1.3
+cmake==3.26.3
+comm @ file:///croot/comm_1671231121260/work
+conda @ file:///croot/conda_1689269889729/work
+conda-content-trust @ file:///tmp/abs_5952f1c8-355c-4855-ad2e-538535021ba5h26t22e5/croots/recipe/conda-content-trust_1658126371814/work
+conda-package-handling @ file:///croot/conda-package-handling_1672865015732/work
+conda_package_streaming @ file:///croot/conda-package-streaming_1670508151586/work
+ConfigArgParse==1.5.3
+contourpy==1.0.7
+coverage==7.2.3
+cryptography @ file:///croot/cryptography_1677533068310/work
+cycler==0.11.0
+dash==2.10.2
+dash-core-components==2.0.0
+dash-html-components==2.0.0
+dash-table==5.0.0
+debugpy @ file:///home/builder/ci_310/debugpy_1640789504635/work
+decorator @ file:///opt/conda/conda-bld/decorator_1643638310831/work
+defusedxml==0.7.1
+Deprecated==1.2.13
+diagnostic-updater==1.11.0
+dill==0.3.6
+distro==1.8.0
+docutils==0.19
+dynamic-reconfigure==1.7.3
+exceptiongroup==1.1.1
+executing @ file:///opt/conda/conda-bld/executing_1646925071911/work
+fastapi==0.95.1
+fastjsonschema==2.16.3
+filelock==3.12.0
+flake8==6.0.0
+Flask==2.2.5
+flatbuffers==23.3.3
+fonttools==4.39.3
+fqdn==1.5.1
+future==0.18.3
+gast==0.4.0
+gazebo-ros==2.9.2
+gencpp==0.7.0
+geneus==3.0.0
+genlisp==0.4.18
+genmsg==0.6.0
+gennodejs==2.0.1
+genpy==0.6.15
+google-auth==2.17.3
+google-auth-oauthlib==1.0.0
+google-pasta==0.2.0
+grpcio==1.54.0
+h11==0.14.0
+h5py==3.8.0
+httptools==0.5.0
+idna @ file:///croot/idna_1666125576474/work
+imageio==2.27.0
+importlib-resources==5.12.0
+iniconfig==2.0.0
+ipykernel @ file:///croot/ipykernel_1671488378391/work
+ipympl==0.9.3
+ipython @ file:///croot/ipython_1676582224036/work
+ipython-genutils==0.2.0
+ipywidgets==8.0.6
+isoduration==20.11.0
+isort==5.12.0
+itsdangerous==2.1.2
+jax==0.4.8
+jedi @ file:///tmp/build/80754af9/jedi_1644315229345/work
+Jinja2==3.1.2
+joblib==1.2.0
+jsonpatch @ file:///tmp/build/80754af9/jsonpatch_1615747632069/work
+jsonpointer==2.3
+jsonschema==4.17.3
+jupyter==1.0.0
+jupyter-console==6.6.3
+jupyter-events==0.6.3
+jupyter_client @ file:///croot/jupyter_client_1680171862562/work
+jupyter_core @ file:///croot/jupyter_core_1679906564508/work
+jupyter_server==2.5.0
+jupyter_server_terminals==0.4.4
+jupyterlab-pygments==0.2.2
+jupyterlab-widgets==3.0.7
+kconfiglib==14.1.0
+keras==2.12.0
+kiwisolver==1.4.4
+lazy-object-proxy==1.9.0
+lazy_loader==0.2
+libclang==16.0.0
+lightning-utilities==0.9.0
+line-profiler==4.0.3
+lit==16.0.1
+MarkupSafe==2.1.2
+matplotlib==3.7.1
+matplotlib-inline @ file:///opt/conda/conda-bld/matplotlib-inline_1662014470464/work
+mavros==1.15.0
+mavsdk==1.4.5
+mccabe==0.7.0
+memory-profiler==0.61.0
+message-filters==1.15.14
+mistune==2.0.5
+ml-dtypes==0.1.0
+mpmath==1.3.0
+nbclassic==0.5.5
+nbclient==0.7.3
+nbconvert==7.3.0
+nbformat==5.7.0
+nest-asyncio @ file:///croot/nest-asyncio_1672387112409/work
+networkx==2.8.8
+notebook==6.5.4
+notebook_shim==0.2.2
+numpy==1.23.5
+nunavut==2.0.9
+nvidia-cublas-cu11==11.10.3.66
+nvidia-cuda-cupti-cu11==11.7.101
+nvidia-cuda-nvrtc-cu11==11.7.99
+nvidia-cuda-runtime-cu11==11.7.99
+nvidia-cudnn-cu11==8.5.0.96
+nvidia-cufft-cu11==10.9.0.58
+nvidia-curand-cu11==10.2.10.91
+nvidia-cusolver-cu11==11.4.0.1
+nvidia-cusparse-cu11==11.7.4.91
+nvidia-nccl-cu11==2.14.3
+nvidia-nvtx-cu11==11.7.91
+oauthlib==3.2.2
+onnx==1.14.0
+open3d==0.17.0
+opencv-contrib-python==4.7.0.72
+opencv-python==4.7.0.72
+opt-einsum==3.3.0
+packaging==23.0
+pandas==2.0.0
+pandocfilters==1.5.0
+parso @ file:///opt/conda/conda-bld/parso_1641458642106/work
+pexpect @ file:///tmp/build/80754af9/pexpect_1605563209008/work
+pickleshare @ file:///tmp/build/80754af9/pickleshare_1606932040724/work
+Pillow==9.5.0
+pkgconfig==1.5.5
+platformdirs @ file:///opt/conda/conda-bld/platformdirs_1662711380096/work
+plotly==5.15.0
+pluggy @ file:///tmp/build/80754af9/pluggy_1648024709248/work
+prometheus-client==0.16.0
+prompt-toolkit @ file:///croot/prompt-toolkit_1672387306916/work
+protobuf==3.20.1
+psutil @ file:///opt/conda/conda-bld/psutil_1656431268089/work
+ptyprocess @ file:///tmp/build/80754af9/ptyprocess_1609355006118/work/dist/ptyprocess-0.7.0-py2.py3-none-any.whl
+pure-eval @ file:///opt/conda/conda-bld/pure_eval_1646925070566/work
+py-cpuinfo==9.0.0
+pyasn1==0.5.0
+pyasn1-modules==0.3.0
+pycodestyle==2.10.0
+pycosat @ file:///croot/pycosat_1666805502580/work
+pycparser @ file:///tmp/build/80754af9/pycparser_1636541352034/work
+pydsdl==1.18.0
+pyFFTW==0.13.1
+pyflakes==3.0.1
+Pygments @ file:///opt/conda/conda-bld/pygments_1644249106324/work
+pylint==2.17.3
+pyLSHash==0.1.1
+pymavlink==2.4.37
+pyOpenSSL @ file:///croot/pyopenssl_1677607685877/work
+pyparsing==3.0.9
+pyquaternion==0.9.9
+pyros-genmsg==0.5.8
+pyrsistent==0.19.3
+pyserial==3.5
+PySocks @ file:///home/builder/ci_310/pysocks_1640793678128/work
+pytest==7.4.0
+pytest-benchmark==4.0.0
+pytest-cov==4.1.0
+python-dateutil==2.8.2
+python-dotenv==1.0.0
+python-json-logger==2.0.7
+python-tsp==0.3.1
+pytz==2023.3
+pyulog==1.0.1
+PyWavelets==1.4.1
+PyYAML==6.0
+pyzmq==25.0.2
+qtconsole==5.4.2
+QtPy==2.3.1
+requests @ file:///croot/requests_1678709721434/work
+requests-oauthlib==1.3.1
+rfc3339-validator==0.1.4
+rfc3986-validator==0.1.1
+rosbag==1.15.14
+rosboost-cfg==1.15.8
+rosclean==1.15.8
+roscreate==1.15.8
+rosgraph==1.15.14
+roslaunch==1.15.14
+roslib==1.15.8
+roslz4==1.15.14
+rosmake==1.15.8
+rosmaster==1.15.14
+rosmsg==1.15.14
+rosnode==1.15.14
+rosparam==1.15.14
+rospkg==1.5.0
+rospy==1.15.14
+rosservice==1.15.14
+rostest==1.15.14
+rostopic==1.15.14
+rosunit==1.15.8
+roswtf==1.15.14
+rsa==4.9
+ruamel.yaml @ file:///croot/ruamel.yaml_1666304550667/work
+ruamel.yaml.clib @ file:///croot/ruamel.yaml.clib_1666302247304/work
+scikit-image==0.20.0
+scikit-learn==1.2.2
+scipy==1.10.1
+seaborn==0.12.2
+Send2Trash==1.8.0
+sensor-msgs==1.13.1
+sentry-sdk==1.20.0
+Shapely==1.8.0
+simplekml==1.3.6
+six @ file:///tmp/build/80754af9/six_1644875935023/work
+smclib==1.8.6
+smopy==0.0.8
+sniffio==1.3.0
+soupsieve==2.4
+stack-data @ file:///opt/conda/conda-bld/stack_data_1646927590127/work
+starlette==0.26.1
+sympy==1.11.1
+tabulate==0.8.10
+tenacity==8.2.2
+tensorboard==2.12.2
+tensorboard-data-server==0.7.0
+tensorboard-plugin-wit==1.8.1
+tensorflow-estimator==2.12.0
+tensorflow-io-gcs-filesystem==0.32.0
+termcolor==2.2.0
+terminado==0.17.1
+tf==1.13.2
+tf2-py==0.7.5
+tf2-ros==0.7.5
+thop==0.1.1.post2209072238
+threadpoolctl==3.1.0
+tifffile==2023.4.12
+tinycss2==1.2.1
+tomli==2.0.1
+toolz @ file:///croot/toolz_1667464077321/work
+topic-tools==1.15.14
+torch==2.0.0+cpu
+torchaudio==2.0.1+cpu
+torchmetrics==1.0.1
+torchvision==0.15.1
+tornado @ file:///opt/conda/conda-bld/tornado_1662061693373/work
+tqdm==4.65.0
+traitlets @ file:///croot/traitlets_1671143879854/work
+trimesh==3.21.7
+triton==2.0.0
+tsplib95==0.7.1
+typing_extensions==4.5.0
+tzdata==2023.3
+ultralytics==8.0.63
+uri-template==1.2.0
+urllib3 @ file:///croot/urllib3_1680254681959/work
+utm==0.7.0
+uvicorn==0.21.1
+uvloop==0.17.0
+watchfiles==0.19.0
+wcwidth @ file:///Users/ktietz/demo/mc3/conda-bld/wcwidth_1629357192024/work
+webcolors==1.13
+webencodings==0.5.1
+websocket-client==1.5.1
+websockets==11.0.2
+Werkzeug==2.2.3
+widgetsnbextension==4.0.7
+wrapt==1.14.1
+zstandard @ file:///croot/zstandard_1677013143055/work

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,0 @@
-pytest
-coverage
-pytest-benchmark

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,3 @@
 pytest
 coverage
+pytest-benchmark

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,8 @@ torch
 opencv-python
 numpy
 torchmetrics
+
+# Testing tools
+pytest
+coverage
+pytest-benchmark

--- a/tests/segmentation_test.py
+++ b/tests/segmentation_test.py
@@ -5,9 +5,9 @@ import numpy as np
 import torch
 from torchmetrics import JaccardIndex
 
-def test_runs_without_error():
+def test_runs_without_error(benchmark):
     rand_img = np.random.randint(0, 255, size=(100, 100, 3), dtype=np.uint8)
-    pred_mask, pred_colors = segment_image(rand_img)
+    pred_mask, pred_colors = benchmark(segment_image, rand_img)
     assert pred_mask.shape == rand_img.shape[:-1]
     assert pred_colors.shape == (3, 3)
 


### PR DESCRIPTION
This lets us view the time it took to complete certain function calls. Activating the benchmarks doesn't require anything besides installing the extension and running the tests normally, and the output looks like this:
![image](https://github.com/uci-uav-forge/unit-testing-example/assets/48658337/6215b334-edd4-4ea8-bea1-2f07fc2703a2)
